### PR TITLE
Add json parameter to skip scans during host registration via API

### DIFF
--- a/src/deterrers-app/hostadmin/api/schema.md
+++ b/src/deterrers-app/hostadmin/api/schema.md
@@ -147,7 +147,10 @@ Edit only the internet service profile of host 0.0.0.0 to 'HTTP':
                 application/json:
                     schema: {
                         'action' : <'register'|'block'>,
-                        'ipv4_addrs' : [<ip>,]
+                        'ipv4_addrs' : [<ip>,],
+                        'skip_scan':
+                            'type': boolean,
+                            'default': false,
                     }
             responses:
                 '200':
@@ -157,3 +160,7 @@ Example:
 Start registration of host 0.0.0.0:
 
     curl -X POST -H 'Authorization: Token <user_token>' -H "Content-Type: application/json" -d '{"action" : "register", "ipv4_addrs" : ["0.0.0.0"]}' https://deterrers.rz.uos.de:443/hostadmin/api/action/
+
+Start registration of host 0.0.0.0 without registration scan: 
+    
+    curl -X POST -H 'Authorization: Token <user_token>' -H "Content-Type: application/json" -d '{"action" : "register", "ipv4_addrs" : ["0.0.0.0"], "skip_scan" : true}' https://deterrers.rz.uos.de:443/hostadmin/api/action/

--- a/src/deterrers-app/hostadmin/api/serializers.py
+++ b/src/deterrers-app/hostadmin/api/serializers.py
@@ -109,3 +109,4 @@ class HostActionSerializer(serializers.Serializer):
         required=True,
         child=serializers.IPAddressField(protocol='ipv4')
     )
+    skip_scan = serializers.BooleanField(default=False)


### PR DESCRIPTION
Allows to skip the scan during registration via the json parameter `skip_test` in the API.

refs #13