### PR TITLE
Fixes the search for max CVSS score in a vulnerability report

### DIFF
--- a/src/deterrers-app/hostadmin/views.py
+++ b/src/deterrers-app/hostadmin/views.py
@@ -1220,7 +1220,7 @@ def scanner_registration_alert(request):
                                            for admin_id in host.admin_ids
                                            if admin_id not in departments]
                         max_sev = max(
-                            [v.cvss_base_score for v in block_reasons],
+                            [v.cvss_base_score for v in vulnerabilities],
                             default=None
                         )
                         if passed:
@@ -1470,7 +1470,7 @@ def scanner_periodic_alert(request):
                         # get highest CVSS
                         max_sev = max(
                             [v.cvss_base_score
-                             for v in block_reasons.extend(notify_reasons)],
+                             for v in vulnerabilities],
                             default=None
                         )
                         # block if there were reasons found


### PR DESCRIPTION
Fixes an issue with searching for the max CVSS score in a list of vulnerability results where two lists were merged but .extend() did not return the merged list. Now the max CVSS score is searched among all vulnerability results of a report and not only those results which are returned by the risk assessment.