### PR TITLE
Fix fw sync

### DIFF
--- a/src/deterrers-app/hostadmin/api/api_views.py
+++ b/src/deterrers-app/hostadmin/api/api_views.py
@@ -259,7 +259,7 @@ def __update_host_logic(ipam: IPAMWrapper,
                 if not set_host_offline(str(host.ipv4_addr)):
                     raise Http500("Could not set host offline")
             else:
-                if not set_host_online(str(host.ipv4_addr)):
+                if not set_host_online(host):
                     raise Http500("Could not set new service profile for host")
 
         # auto-add some host-based policies
@@ -517,7 +517,7 @@ def register_bulk(
                     # Skip scan and change the perimeter firewall
                     # configuration so that only hosts service
                     # profile is allowed
-                    if not set_host_online(str(host.ipv4_addr)):
+                    if not set_host_online(host):
                         raise Http500("Couldn't set host online!")
                 else:
                     # Otherwise start vulnerability scan

--- a/src/deterrers-app/hostadmin/api/api_views.py
+++ b/src/deterrers-app/hostadmin/api/api_views.py
@@ -195,7 +195,7 @@ def __remove_host(request) -> Response:
 
         # block
         if host.status == HostStatus.ONLINE:
-            if not set_host_offline(str(host.ipv4_addr)):
+            if not set_host_offline(host):
                 raise Http500("Host could not be set offline")
 
         # set all DETERRERS fields to blank
@@ -256,7 +256,7 @@ def __update_host_logic(ipam: IPAMWrapper,
         # if host is already online, update the perimeter FW
         if host.status == HostStatus.ONLINE:
             if host.service_profile == HostServiceProfile.EMPTY:
-                if not set_host_offline(str(host.ipv4_addr)):
+                if not set_host_offline(host):
                     raise Http500("Could not set host offline")
             else:
                 if not set_host_online(host):
@@ -564,6 +564,7 @@ def block_bulk(hostadmin: MyUser, ipv4_addrs: set[str]):
             raise Http404()
 
         # check if all requested hosts are permitted for this hostadmin
+        hosts = set()
         for ipv4 in ipv4_addrs:
             # get host
             host = ipam.get_host_info_from_ip(ipv4)
@@ -578,9 +579,10 @@ def block_bulk(hostadmin: MyUser, ipv4_addrs: set[str]):
             # check if host is actually valid
             if not host.is_valid():
                 raise Http409()
+            hosts.add(host)
 
     # set all hosts offline
-    set_host_bulk_offline(ipv4_addrs)
+    set_host_bulk_offline(hosts)
 
 
 @api_view(['POST'])

--- a/src/deterrers-app/hostadmin/util.py
+++ b/src/deterrers-app/hostadmin/util.py
@@ -135,17 +135,19 @@ def available_actions(host: MyHost) -> dict:
     return flags
 
 
-def set_host_offline(host_ipv4: str) -> bool:
+def set_host_offline(host: MyHost) -> bool:
     """
     Block a host at the perimeter firewall and update the status in the IPAM.
     Removes host also from periodic scan.
 
     Args:
-        host_ipv4 (str): IPv4 address of the host.
+        host (MyHost): Host to set offline.
 
     Returns:
         bool: Returns True on success and False if something went wrong.
     """
+    logger.info("Set host %s offline.", str(host.ipv4_addr))
+
     with IPAMWrapper(
         settings.IPAM_USERNAME,
         settings.IPAM_SECRET_KEY,
@@ -168,7 +170,6 @@ def set_host_offline(host_ipv4: str) -> bool:
                 if not fw.enter_ok:
                     return False
 
-                host = ipam.get_host_info_from_ip(host_ipv4)
                 ips_to_block = ipam.get_IP6Addresses(host)
                 ips_to_block.add(str(host.ipv4_addr))
                 # change the perimeter firewall configuration so that host
@@ -189,11 +190,11 @@ def set_host_offline(host_ipv4: str) -> bool:
     return True
 
 
-def set_host_bulk_offline(host_ipv4s: set[str]) -> bool:
+def set_host_bulk_offline(hosts: set[MyHost]) -> bool:
     # TODO: optimize for better performance by querying many ips to FW
-    for ipv4 in host_ipv4s:
-        if not set_host_offline(ipv4):
-            logger.error("Couldn't block host: %s", ipv4)
+    for host in hosts:
+        if not set_host_offline(host):
+            logger.error("Couldn't block host: %s", str(host))
         continue
     return True
 

--- a/src/deterrers-app/hostadmin/util.py
+++ b/src/deterrers-app/hostadmin/util.py
@@ -198,7 +198,7 @@ def set_host_bulk_offline(host_ipv4s: set[str]) -> bool:
     return True
 
 
-def set_host_online(host_ipv4: str) -> bool:
+def set_host_online(host: MyHost) -> bool:
     """
     Change the perimeter firewall configuration so that only host's
     service profile is allowed.
@@ -206,12 +206,12 @@ def set_host_online(host_ipv4: str) -> bool:
     Add host to the periodic scan.
 
     Args:
-        host_ipv4 (str): IPv4 address of the host.
+        host (MyHost): Hostobject to set online.
 
     Returns:
         bool: Returns True on success and False if something goes wrong.
     """
-    logger.info("Set host %s online.", host_ipv4)
+    logger.info("Set host %s online.", str(host.ipv4_addr))
 
     with IPAMWrapper(
         settings.IPAM_USERNAME,
@@ -235,7 +235,6 @@ def set_host_online(host_ipv4: str) -> bool:
                 if not fw.enter_ok:
                     return False
 
-                host = ipam.get_host_info_from_ip(host_ipv4)
                 if (
                     not host.is_valid()
                     or host.service_profile is HostServiceProfile.EMPTY
@@ -247,11 +246,11 @@ def set_host_online(host_ipv4: str) -> bool:
                 response_url = (settings.DOMAIN_NAME
                                 + reverse('scanner_periodic_alert'))
                 if not scanner.add_host_to_periodic_scans(
-                    host_ip=host_ipv4,
+                    host_ip=str(host.ipv4_addr),
                     alert_dest_url=response_url
                 ):
                     logger.error("Couldn't add host %s to periodic scan!",
-                                 host_ipv4)
+                                 str(host.ipv4_addr))
                     return False
 
                 # get IPv6 address to all IPv4 address

--- a/src/deterrers-app/hostadmin/views.py
+++ b/src/deterrers-app/hostadmin/views.py
@@ -487,7 +487,7 @@ def update_host_detail(request, ipv4: str):
                                 'host/update_host_form.html',
                                 context=context
                             )
-                        if not set_host_online(str(host.ipv4_addr)):
+                        if not set_host_online(host):
                             form.add_error(
                                 None,
                                 "Perimeter firewall could not be updated."
@@ -1199,7 +1199,7 @@ def scanner_registration_alert(request):
                             )
                             # change the perimeter firewall configuration so
                             # that only hosts service profile is allowed
-                            if not set_host_online(host_ipv4):
+                            if not set_host_online(host):
                                 raise RuntimeError("Couldn't set host online!")
                         else:
                             passed = False

--- a/src/deterrers-app/hostadmin/views.py
+++ b/src/deterrers-app/hostadmin/views.py
@@ -888,7 +888,7 @@ def block_host(request, ipv4: str):
     if not available_actions(host).get('can_block'):
         raise Http404()
 
-    if not set_host_offline(ipv4):
+    if not set_host_offline(host):
         messages.error(request, "Couldn't block host!")
 
     # redirect to a new URL:
@@ -1085,7 +1085,7 @@ def remove_host(request, ipv4: str):
 
         # block
         if host.status == HostStatus.ONLINE:
-            if not set_host_offline(str(host.ipv4_addr)):
+            if not set_host_offline(host):
                 return HttpResponse(status=500)
 
         # set all DETERRERS fields to blank
@@ -1208,7 +1208,7 @@ def scanner_registration_alert(request):
                                  + "will be blocked."),
                                 host_ipv4
                             )
-                            if not set_host_offline(host_ipv4):
+                            if not set_host_offline(host):
                                 raise RuntimeError("Couldn't block host")
 
                         # get HTML report and send via e-mail to admin
@@ -1480,7 +1480,7 @@ def scanner_periodic_alert(request):
                                  + "and will be blocked."),
                                 str(host.ipv4_addr)
                             )
-                            if not set_host_offline(str(host.ipv4_addr)):
+                            if not set_host_offline(host):
                                 raise RuntimeError("Couldn't block host")
                             # deduce admin email addr and filter out
                             # departments


### PR DESCRIPTION
Fixes a bug which lead to the perimeter FW being out of sync when a registered hosts service profile was updated. Was caused by the not setting the new service profile before querying the host data again in set_host_online()
Fixed by passing the actual host object to set_host_online() instead of only the IP address. This also saves one request to the IPAM therefore improving performance.
Same changes were performed for set_host_offline() and set_host_bulk_offline() for performance improvement.