### PR TITLE
Change host based policy data format

### DIFF
--- a/project/application/main/api/api_views.py
+++ b/project/application/main/api/api_views.py
@@ -272,8 +272,9 @@ def __update_host_logic(ipam: IPAMWrapper,
                 # allow SSH standard port 22 over TCP if a service profile
                 # is specified
                 host.add_host_based_policy(
-                    HostBasedPolicySrc.ANY.value, ['22'],
-                    HostBasedPolicyProtocol.TCP.value
+                    HostBasedPolicySrc.ANY,
+                    ['22'],
+                    HostBasedPolicyProtocol.TCP
                 )
                 match s_p:
                     case HostServiceProfile.SSH:
@@ -285,14 +286,14 @@ def __update_host_logic(ipam: IPAMWrapper,
                         # allow HTTP and HTTPS standard ports 80 and 443
                         # over TCP
                         host.add_host_based_policy(
-                            HostBasedPolicySrc.ANY.value,
+                            HostBasedPolicySrc.ANY,
                             ['80'],
-                            HostBasedPolicyProtocol.TCP.value
+                            HostBasedPolicyProtocol.TCP
                         )
                         host.add_host_based_policy(
-                            HostBasedPolicySrc.ANY.value,
+                            HostBasedPolicySrc.ANY,
                             ['443'],
-                            HostBasedPolicyProtocol.TCP.value
+                            HostBasedPolicyProtocol.TCP
                         )
             case HostServiceProfile.MULTIPURPOSE:
                 # allow nothing else; users are expected to configure their

--- a/project/application/main/api/serializers.py
+++ b/project/application/main/api/serializers.py
@@ -2,8 +2,8 @@ from rest_framework import serializers
 
 from main.core.rule_generator import HostBasedPolicy
 from main.core.contracts import (HostStatus,
-                                      HostServiceProfile,
-                                      HostFW)
+                                 HostServiceProfile,
+                                 HostFW)
 
 
 class MyHostSerializer(serializers.Serializer):

--- a/project/application/main/core/data_logic/data_mock.py
+++ b/project/application/main/core/data_logic/data_mock.py
@@ -6,8 +6,8 @@ import os
 from main.core.data_logic.data_abstract import DataAbstract
 from main.core.host import MyHost
 from main.core.contracts import (HostStatus,
-                                      HostServiceProfile,
-                                      HostFW)
+                                 HostServiceProfile,
+                                 HostFW)
 from main.core.rule_generator import HostBasedPolicy
 
 logger = logging.getLogger(__name__)

--- a/project/application/main/core/data_logic/ipam_wrapper.py
+++ b/project/application/main/core/data_logic/ipam_wrapper.py
@@ -8,8 +8,8 @@ import ipaddress
 from main.core.data_logic.data_abstract import DataAbstract
 from main.core.host import MyHost
 from main.core.contracts import (HostStatus,
-                                      HostServiceProfile,
-                                      HostFW)
+                                 HostServiceProfile,
+                                 HostFW)
 from main.core.rule_generator import HostBasedPolicy
 
 logger = logging.getLogger(__name__)

--- a/project/application/main/core/host.py
+++ b/project/application/main/core/host.py
@@ -5,7 +5,9 @@ from django.urls import reverse
 from .rule_generator import HostBasedPolicy
 from .contracts import (HostFW,
                         HostServiceProfile,
-                        HostStatus)
+                        HostStatus,
+                        HostBasedPolicyProtocol,
+                        HostBasedPolicySrc)
 
 
 class MyHost():
@@ -97,16 +99,19 @@ class MyHost():
         except AttributeError:
             return "Not available!"
 
-    def add_host_based_policy(self, subnets: dict, ports: list[str],
-                              proto: str) -> bool:
+    def add_host_based_policy(
+        self,
+        subnets: HostBasedPolicySrc,
+        ports: list[str],
+        proto: HostBasedPolicyProtocol
+    ) -> bool:
         """
         Adds a host-based FW policy to a host.
 
         Args:
-            subnets (dict): A dict with fields 'name' and 'range' that specify
-            the allow-src.
+            subnets (HostBasedPolicySrc): Policy source.
             ports (list[str]): List of port definitions that are to be allowed.
-            proto (str): Protocol to allow.
+            proto (HostBasedPolicyProtocol): Protocol to allow.
 
         Returns:
             bool: Returns True if policy was added and False if policy is

--- a/project/application/main/core/rule_generator.py
+++ b/project/application/main/core/rule_generator.py
@@ -66,7 +66,7 @@ class HostBasedPolicy():
         elems = string.split(cls.SEPARATOR_v2)
         if len(elems) == 4:
             p_id = elems[0]
-            allow_src = HostBasedPolicySrc[elems[1]]
+            allow_src = HostBasedPolicySrc[elems[1]].value
             allow_ports = set(elems[2].split(","))
             allow_proto = elems[3]
             return cls(id=p_id,

--- a/project/application/main/core/rule_generator.py
+++ b/project/application/main/core/rule_generator.py
@@ -66,7 +66,9 @@ class HostBasedPolicy():
         elems = string.split(cls.SEPARATOR_v2)
         if len(elems) == 4:
             p_id = elems[0]
-            allow_src = HostBasedPolicySrc[elems[1]].value
+            for src in HostBasedPolicySrc:
+                if elems[1] == src.value['name']:
+                    allow_src = src.value
             allow_ports = set(elems[2].split(","))
             allow_proto = elems[3]
             return cls(id=p_id,
@@ -86,7 +88,7 @@ class HostBasedPolicy():
         """
         return (self.id
                 + self.SEPARATOR_v2
-                + self.allow_src["name"]
+                + HostBasedPolicySrc(self.allow_src).name
                 + self.SEPARATOR_v2
                 + ",".join(self.allow_ports)
                 + self.SEPARATOR_v2

--- a/project/application/main/core/rule_generator.py
+++ b/project/application/main/core/rule_generator.py
@@ -66,9 +66,7 @@ class HostBasedPolicy():
         elems = string.split(cls.SEPARATOR_v2)
         if len(elems) == 4:
             p_id = elems[0]
-            for src in HostBasedPolicySrc:
-                if elems[1] == src.value['name']:
-                    allow_src = src.value
+            allow_src = HostBasedPolicySrc[elems[1]].value
             allow_ports = set(elems[2].split(","))
             allow_proto = elems[3]
             return cls(id=p_id,

--- a/project/application/main/core/rule_generator.py
+++ b/project/application/main/core/rule_generator.py
@@ -16,8 +16,8 @@ class HostBasedPolicy():
     """
     Class representing a host-based firewall policy.
     """
-    SEPERATOR_v1 = '___'
-    SEPERATOR_v2 = '|_|_|'
+    SEPARATOR_v1 = '___'
+    SEPARATOR_v2 = '***'
 
     def __init__(
         self,
@@ -36,7 +36,10 @@ class HostBasedPolicy():
         self.allow_proto = allow_proto
 
     @classmethod
-    def from_string(cls, string: str) -> HostBasedPolicy | None:
+    def from_string(
+        cls: HostBasedPolicy,
+        string: str
+    ) -> HostBasedPolicy | None:
         """
         Construct an instance of HostBasedPolicy from its string
         representation. Supports the old format as well as the new format.
@@ -49,25 +52,25 @@ class HostBasedPolicy():
             something goes wrong.
         """
         # format version 1
-        elems = string.split(cls.SEPERATOR_v1)
+        elems = string.split(cls.SEPARATOR_v1)
         if len(elems) == 4:
             p_id = elems[0]
-            allow_srcs = json.loads(elems[1])
+            allow_src = json.loads(elems[1])
             allow_ports = set(json.loads(elems[2]))
             allow_proto = elems[3]
             return cls(id=p_id,
-                       allow_srcs=allow_srcs,
+                       allow_src=allow_src,
                        allow_ports=allow_ports,
                        allow_proto=allow_proto)
         # format version 2
-        elems = string.split(cls.SEPERATOR_v2)
+        elems = string.split(cls.SEPARATOR_v2)
         if len(elems) == 4:
             p_id = elems[0]
-            allow_srcs = HostBasedPolicySrc[elems[1]]
+            allow_src = HostBasedPolicySrc[elems[1]]
             allow_ports = set(elems[2].split(","))
             allow_proto = elems[3]
             return cls(id=p_id,
-                       allow_srcs=allow_srcs,
+                       allow_src=allow_src,
                        allow_ports=allow_ports,
                        allow_proto=allow_proto)
         logger.error("Invalid string input: %s", string)
@@ -82,11 +85,11 @@ class HostBasedPolicy():
             str: Returns the string representation.
         """
         return (self.id
-                + self.SEPERATOR_v1
+                + self.SEPARATOR_v1
                 + self.allow_src["name"]
-                + self.SEPERATOR_v1
+                + self.SEPARATOR_v1
                 + ",".join(self.allow_ports)
-                + self.SEPERATOR_v1
+                + self.SEPARATOR_v1
                 + self.allow_proto)
 
     def is_subset_of(self, p: HostBasedPolicy) -> bool:

--- a/project/application/main/core/rule_generator.py
+++ b/project/application/main/core/rule_generator.py
@@ -6,7 +6,7 @@ import uuid
 import json
 import ipaddress
 
-from .contracts import HostFW, HostBasedPolicySrc
+from .contracts import HostFW, HostBasedPolicySrc, HostBasedPolicyProtocol
 
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class HostBasedPolicy():
                 + self.SEPARATOR_v2
                 + ",".join(self.allow_ports)
                 + self.SEPARATOR_v2
-                + self.allow_proto)
+                + HostBasedPolicyProtocol(self.allow_proto).name)
 
     def is_subset_of(self, p: HostBasedPolicy) -> bool:
         """

--- a/project/application/main/core/rule_generator.py
+++ b/project/application/main/core/rule_generator.py
@@ -85,11 +85,11 @@ class HostBasedPolicy():
             str: Returns the string representation.
         """
         return (self.id
-                + self.SEPARATOR_v1
+                + self.SEPARATOR_v2
                 + self.allow_src["name"]
-                + self.SEPARATOR_v1
+                + self.SEPARATOR_v2
                 + ",".join(self.allow_ports)
-                + self.SEPARATOR_v1
+                + self.SEPARATOR_v2
                 + self.allow_proto)
 
     def is_subset_of(self, p: HostBasedPolicy) -> bool:

--- a/project/application/main/forms.py
+++ b/project/application/main/forms.py
@@ -101,7 +101,7 @@ class AddHostRulesForm(forms.Form):
 
     SUBNET_CHOICES = [(sub.name, sub.display())
                       for sub in HostBasedPolicySrc]
-    PROTOCOL_CHOICES = [(proto.value, proto.value)
+    PROTOCOL_CHOICES = [(proto.name, proto.value)
                         for proto in HostBasedPolicyProtocol]
 
     subnet = forms.ChoiceField(

--- a/project/application/main/management/commands/update_fw_policy_format.py
+++ b/project/application/main/management/commands/update_fw_policy_format.py
@@ -1,12 +1,8 @@
 from django.core.management.base import BaseCommand
-import os
-import argparse
 import logging
 
 from django.conf import settings
 
-from main.core.contracts import HostStatus, HostServiceProfile
-from main.core.host import MyHost
 if settings.IPAM_DUMMY:
     from main.core.data_logic.data_mock \
         import DataMockWrapper as IPAMWrapper
@@ -18,41 +14,35 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Updates all definitions of host-based FW policies in the IPAM from the old format to a new one.'
+    help = ('Updates all definitions of host-based FW policies in the IPAM '
+            + 'from the old format to a new one.')
 
     def handle(self, *args, **options):
         logger.info("Start!")
 
-        while True:
-            try:
-                ipam_username = settings.IPAM_USERNAME
-                ipam_password = settings.IPAM_SECRET_KEY
-                ipam_url = settings.IPAM_URL
-            except Exception:
-                ipam_username = os.environ.get('IPAM_USERNAME')
-                ipam_password = os.environ.get('IPAM_SECRET_KEY',)
-                ipam_url = os.environ.get('IPAM_URL')
-            with IPAMWrapper(
-                ipam_username,
-                ipam_password,
-                ipam_url
-            ) as ipam:
-                if not ipam.enter_ok:
-                    continue
+        ipam_username = settings.IPAM_USERNAME
+        ipam_password = settings.IPAM_SECRET_KEY
+        ipam_url = settings.IPAM_URL
+        with IPAMWrapper(
+            ipam_username,
+            ipam_password,
+            ipam_url
+        ) as ipam:
+            if not ipam.enter_ok:
+                return
 
-                # get all hosts in IPAM
-                logger.info("Get assets from IPAM!")
-                ipam_hosts_total = {}
-                admin_tag_names = ipam.get_all_admin_names()
-                for a_tag_name in admin_tag_names:
-                    hosts = ipam.get_hosts_of_admin(
-                        admin_name=a_tag_name
-                    )
-                    for host in hosts:
-                        ipam_hosts_total[str(host.ipv4_addr)] = host
-                
-                for ipv4, host in ipam_hosts_total.items():
-                    if host.is_valid() and len(host.host_based_policies) > 0:
-                        logger.info("Update policy format of host %s", ipv4)
-                        ipam.update_host_info(host)
+            # get all hosts in IPAM
+            logger.info("Get assets from IPAM!")
+            ipam_hosts_total = {}
+            admin_tag_names = ipam.get_all_admin_names()
+            for a_tag_name in admin_tag_names:
+                hosts = ipam.get_hosts_of_admin(
+                    admin_name=a_tag_name
+                )
+                for host in hosts:
+                    ipam_hosts_total[str(host.ipv4_addr)] = host
 
+            for ipv4, host in ipam_hosts_total.items():
+                if host.is_valid() and len(host.host_based_policies) > 0:
+                    logger.info("Update policy format of host %s", ipv4)
+                    ipam.update_host_info(host)

--- a/project/application/main/management/commands/update_fw_policy_format.py
+++ b/project/application/main/management/commands/update_fw_policy_format.py
@@ -1,0 +1,58 @@
+from django.core.management.base import BaseCommand
+import os
+import argparse
+import logging
+
+from django.conf import settings
+
+from main.core.contracts import HostStatus, HostServiceProfile
+from main.core.host import MyHost
+if settings.IPAM_DUMMY:
+    from main.core.data_logic.data_mock \
+        import DataMockWrapper as IPAMWrapper
+else:
+    from main.core.data_logic.ipam_wrapper \
+        import ProteusIPAMWrapper as IPAMWrapper
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Updates all definitions of host-based FW policies in the IPAM from the old format to a new one.'
+
+    def handle(self, *args, **options):
+        logger.info("Start!")
+
+        while True:
+            try:
+                ipam_username = settings.IPAM_USERNAME
+                ipam_password = settings.IPAM_SECRET_KEY
+                ipam_url = settings.IPAM_URL
+            except Exception:
+                ipam_username = os.environ.get('IPAM_USERNAME')
+                ipam_password = os.environ.get('IPAM_SECRET_KEY',)
+                ipam_url = os.environ.get('IPAM_URL')
+            with IPAMWrapper(
+                ipam_username,
+                ipam_password,
+                ipam_url
+            ) as ipam:
+                if not ipam.enter_ok:
+                    continue
+
+                # get all hosts in IPAM
+                logger.info("Get assets from IPAM!")
+                ipam_hosts_total = {}
+                admin_tag_names = ipam.get_all_admin_names()
+                for a_tag_name in admin_tag_names:
+                    hosts = ipam.get_hosts_of_admin(
+                        admin_name=a_tag_name
+                    )
+                    for host in hosts:
+                        ipam_hosts_total[str(host.ipv4_addr)] = host
+                
+                for ipv4, host in ipam_hosts_total:
+                    if host.is_valid() and len(host.host_based_policies) > 0:
+                        logger.info("Update policy format of host %s", ipv4)
+                        ipam.update_host_info(host)
+

--- a/project/application/main/management/commands/update_fw_policy_format.py
+++ b/project/application/main/management/commands/update_fw_policy_format.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
                     for host in hosts:
                         ipam_hosts_total[str(host.ipv4_addr)] = host
                 
-                for ipv4, host in ipam_hosts_total:
+                for ipv4, host in ipam_hosts_total.items():
                     if host.is_valid() and len(host.host_based_policies) > 0:
                         logger.info("Update policy format of host %s", ipv4)
                         ipam.update_host_info(host)

--- a/project/application/main/views.py
+++ b/project/application/main/views.py
@@ -192,9 +192,11 @@ def host_detail_view(request, ipv4: str, tab: str = 'general'):
             if form.is_valid():
                 subnet = HostBasedPolicySrc[
                     form.cleaned_data['subnet']
-                ].value
+                ]
                 ports = form.cleaned_data['ports']
-                proto = form.cleaned_data['protocol']
+                proto = HostBasedPolicyProtocol[
+                    form.cleaned_data['protocol']
+                ]
                 # update the actual model instance
                 if not host.add_host_based_policy(subnet, ports, proto):
                     form.add_error(None, "Rule is redundant!")
@@ -229,7 +231,7 @@ def host_detail_view(request, ipv4: str, tab: str = 'general'):
                     p.allow_src
                 ).display(),
                 'allow_ports': p.allow_ports,
-                'allow_proto': p.allow_proto,
+                'allow_proto': p.allow_proto.value,
                 'id': p.id
             }
             for p in host.host_based_policies],
@@ -512,9 +514,9 @@ def update_host_detail(request, ipv4: str):
                             # allow SSH standard port 22 over TCP if a service
                             # profile is specified
                             host.add_host_based_policy(
-                                HostBasedPolicySrc.ANY.value,
+                                HostBasedPolicySrc.ANY,
                                 ['22'],
-                                HostBasedPolicyProtocol.TCP.value
+                                HostBasedPolicyProtocol.TCP
                             )
                             match s_p:
                                 case HostServiceProfile.SSH:
@@ -526,14 +528,14 @@ def update_host_detail(request, ipv4: str):
                                     # allow HTTP and HTTPS standard ports
                                     # 80 and 443 over TCP
                                     host.add_host_based_policy(
-                                        HostBasedPolicySrc.ANY.value,
+                                        HostBasedPolicySrc.ANY,
                                         ['80'],
-                                        HostBasedPolicyProtocol.TCP.value
+                                        HostBasedPolicyProtocol.TCP
                                     )
                                     host.add_host_based_policy(
-                                        HostBasedPolicySrc.ANY.value,
+                                        HostBasedPolicySrc.ANY,
                                         ['443'],
-                                        HostBasedPolicyProtocol.TCP.value
+                                        HostBasedPolicyProtocol.TCP
                                     )
                         case HostServiceProfile.MULTIPURPOSE:
                             # allow nothing else; users are expected to

--- a/project/application/main/views.py
+++ b/project/application/main/views.py
@@ -226,7 +226,7 @@ def host_detail_view(request, ipv4: str, tab: str = 'general'):
         'host_rules': [
             {
                 'allow_src': HostBasedPolicySrc(
-                    p.allow_srcs
+                    p.allow_src
                 ).display(),
                 'allow_ports': p.allow_ports,
                 'allow_proto': p.allow_proto,


### PR DESCRIPTION
Host-based FW policies are now stored in a new format so that they are more modular and changes to some allow-source-definition won't require an update of the whole data base.
Also the HostBasedPolicy class has been refactored.