### PR TITLE
overrides that mark vulnerabilities as False Positive are now applied…

### DIFF
--- a/project/application/main/core/risk_assessor.py
+++ b/project/application/main/core/risk_assessor.py
@@ -26,7 +26,8 @@ class VulnerabilityScanResult():
         cvss_base_score: float,
         cvss_base_vector: str,
         refs: list[str],
-        description: str
+        description: str,
+        overrides: list[dict]
     ) -> None:
         self.uuid = str(uuid)
         self.host_ip = str(host_ip)
@@ -41,6 +42,7 @@ class VulnerabilityScanResult():
         self.cvss_base_vector = str(cvss_base_vector)
         self.refs = list(refs)
         self.description = description
+        self.overrides = list(overrides)
 
     def to_dict(self) -> dict:
         return self.__dict__
@@ -192,6 +194,12 @@ def assess_vulnerability_risk(
     """
     risk = RiskFlag.NONE
     try:
+        # if there is an override for this vulnerability which sets its
+        # threat-level to False Positive, there is no risk assumed
+        for override in vul.overrides:
+            if override['new_threat'] == 'False Positive':
+                return RiskFlag.NONE
+
         # if still no severity matched CVSS v2 or v3 skip to avoid error
         if vul.cvss_version not in (2, 3):
             return RiskFlag.NONE

--- a/project/application/main/core/scanner/gmp_wrapper.py
+++ b/project/application/main/core/scanner/gmp_wrapper.py
@@ -1379,6 +1379,26 @@ class GmpScannerWrapper(ScannerAbstract):
                     qod = result_xml.xpath('qod/value')[0].text
                     severities = result_xml.xpath('nvt/severities/severity')
                     try:
+                        overrides = []
+                        ors = result_xml.xpath('overrides/override')
+                        for override in ors:
+                            if int(override.xpath('active')[0].text) == 1:
+                                override_id = override.attrib['id']
+                                override_nvt_oid = override.xpath('nvt').attrib['oid']
+                                override_new_threat = override.xpath('new_threat')[0].text
+                                override_new_severity = override.xpath('new_severity')[0].text
+                                overrides.append({
+                                    'id': override_id,
+                                    'nvt_oid': override_nvt_oid,
+                                    'new_threat': override_new_threat,
+                                    'new_severity': float(override_new_severity)
+                                })
+                    except Exception:
+                        logger.exception(
+                            "Couldn't extract all overrides!"
+                        )
+
+                    try:
                         description = result_xml.xpath('description')[0].text
                     except Exception:
                         logger.exception(
@@ -1426,7 +1446,8 @@ class GmpScannerWrapper(ScannerAbstract):
                     cvss_base_score=cvss_base_score,
                     cvss_base_vector=cvss_base_vector,
                     refs=refs,
-                    description=description
+                    description=description,
+                    overrides=overrides
                 )
                 if results.get(host_ip):
                     results[host_ip].append(res)

--- a/project/application/main/util.py
+++ b/project/application/main/util.py
@@ -7,8 +7,8 @@ from django.urls import reverse
 
 from main.core.host import MyHost
 from main.core.contracts import (HostStatus,
-                                      HostServiceProfile,
-                                      HostFW)
+                                 HostServiceProfile,
+                                 HostFW)
 from main.core.risk_assessor import VulnerabilityScanResult
 if settings.IPAM_DUMMY:
     from main.core.data_logic.data_mock \


### PR DESCRIPTION
… during risk assessment

Does what the title says. Not tested yet but should remove False Positives that were entered in vulnerability scanner as overrides.