### PR TITLE
Improvement: ssh keyscan instead paramiko

### DIFF
--- a/project/application/Dockerfile
+++ b/project/application/Dockerfile
@@ -2,6 +2,10 @@
 
 FROM python:3.10-slim-bullseye
 
+# install openssh-client for ssh-keyscan
+RUN apt-get update
+RUN apt-get openssh-client
+
 ENV MICRO_SERVICE=/home/app/microservice
 RUN mkdir -p $MICRO_SERVICE
 RUN mkdir -p $MICRO_SERVICE/static

--- a/project/application/Dockerfile
+++ b/project/application/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile
 
-FROM python:3.10-slim-bullseye
+FROM python:3.13-slim-bullseye
 
 # install openssh-client for ssh-keyscan
 RUN apt-get update

--- a/project/application/Dockerfile
+++ b/project/application/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10-slim-bullseye
 
 # install openssh-client for ssh-keyscan
 RUN apt-get update
-RUN apt-get openssh-client
+RUN apt-get install -y openssh-client
 
 ENV MICRO_SERVICE=/home/app/microservice
 RUN mkdir -p $MICRO_SERVICE

--- a/project/application/Dockerfile-supercronic
+++ b/project/application/Dockerfile-supercronic
@@ -1,6 +1,6 @@
 # Dockerfile
 
-FROM python:3.10-slim-bullseye
+FROM python:3.13-slim-bullseye
 
 
 # install util packages

--- a/project/application/Dockerfile-supercronic
+++ b/project/application/Dockerfile-supercronic
@@ -3,9 +3,9 @@
 FROM python:3.10-slim-bullseye
 
 
-# install cron
+# install util packages
 RUN apt-get update
-RUN apt-get -y install cron curl
+RUN apt-get -y install cron curl openssh-client
 
 # install supercronic
 # Latest releases available at https://github.com/aptible/supercronic/releases

--- a/project/application/main/management/commands/add_ssh_fingerprints.py
+++ b/project/application/main/management/commands/add_ssh_fingerprints.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand
 import os
 
+from django.conf import settings
+
 
 class Command(BaseCommand):
     help = ("Adds the SSH fingerprint of the vulnerability scanner server "
@@ -10,8 +12,12 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args, **options):
-        scanner_url = os.environ['SCANNER_HOSTNAME']
-        port = 22
         known_hosts = f'{os.environ["MICRO_SERVICE"]}/known_hosts'
-        # recreate known_hosts file every time
-        os.system(f"ssh-keyscan -p {port} {scanner_url} > {known_hosts}")
+
+        if settings.SCANNER_DUMMY:
+            pass
+        else:
+            scanner_url = os.environ['SCANNER_HOSTNAME']
+            port = 22
+            # recreate known_hosts file every time
+            os.system(f"ssh-keyscan -p {port} {scanner_url} > {known_hosts}")

--- a/project/application/main/management/commands/add_ssh_fingerprints.py
+++ b/project/application/main/management/commands/add_ssh_fingerprints.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-import paramiko
 import os
 
 
@@ -14,15 +13,5 @@ class Command(BaseCommand):
         scanner_url = os.environ['SCANNER_HOSTNAME']
         port = 22
         known_hosts = f'{os.environ["MICRO_SERVICE"]}/known_hosts'
-        if not os.path.isfile(known_hosts):
-            open(known_hosts, 'x').close()
-
-        transport = paramiko.Transport(scanner_url + ':' + str(port))
-        transport.connect()
-        key = transport.get_remote_server_key()
-        transport.close()
-
-        hostfile = paramiko.HostKeys(filename=known_hosts)
-        hostfile.add(hostname=scanner_url, key=key, keytype=key.get_name())
-
-        hostfile.save(filename=known_hosts)
+        # recreate known_hosts file every time
+        os.system(f"ssh-keyscan -p {port} {scanner_url} > {known_hosts}")

--- a/project/application/requirements.txt
+++ b/project/application/requirements.txt
@@ -1,4 +1,4 @@
-Django == 5.1.17
+Django == 5.1.7
 ldap3 == 2.9.1
 django-python3-ldap == 0.15.8
 requests

--- a/project/application/requirements.txt
+++ b/project/application/requirements.txt
@@ -1,9 +1,9 @@
-Django == 5.0.13
+Django == 5.1.17
 ldap3 == 2.9.1
-django-python3-ldap == 0.15.5
+django-python3-ldap == 0.15.8
 requests
 gunicorn
-python-gvm == 24.6.0
+python-gvm == 26.1.1
 icalendar
 django-bootstrap5
 djangorestframework

--- a/project/application/requirements.txt
+++ b/project/application/requirements.txt
@@ -5,7 +5,6 @@ requests
 gunicorn
 python-gvm == 24.6.0
 icalendar
-paramiko
 django-bootstrap5
 djangorestframework
 pyyaml


### PR DESCRIPTION
Uses openssh's `ssh-keyscan` utility to create known_hosts-file with greenbone vulnerability scanner's SSH fingerprint. This removes the dependency to `paramiko`-python-package.