### PR TITLE
Send scanner alerts via https by default

### DIFF
--- a/project/application/main/core/scanner/gmp_wrapper.py
+++ b/project/application/main/core/scanner/gmp_wrapper.py
@@ -445,6 +445,9 @@ class GmpScannerWrapper(ScannerAbstract):
         Raises:
             GmpAPIError: Raised if couldn't query or modify alert.
         """
+        # check if protocol is given in URL
+        if 'https://' not in deterrers_url or 'http://' not in deterrers_url:
+            deterrers_url = 'https://' + deterrers_url
         response = self.gmp.get_alert(alert_uuid)
         response_status = int(response.xpath('@status')[0])
         if response_status != 200:


### PR DESCRIPTION
Make sure that scanner alerts are send via https if no protocol is given with alert-destination